### PR TITLE
Improvements to path validation

### DIFF
--- a/src/ledcontrol.cpp
+++ b/src/ledcontrol.cpp
@@ -111,9 +111,8 @@ void LEDControl::detectPath()
     } else {
         qDebug() << "Hardware not recognised";
         setDevice("Unknown");
-        setPath("");
+        setPath("Unknown");
     }
-
 }
 
 
@@ -141,8 +140,8 @@ void LEDControl::setPath(QString fp)
 
     if ( !regex.exactMatch(fp) )
     {
-        qDebug() << "validation of file path failed - setting to INVALID";
-        if( !fp.startsWith("INVALID - "))
+        qDebug() << "validation of file path failed";
+        if( !fp.startsWith("INVALID - ") && fp != "Unknown")
         {
             fp = QString("INVALID - %1").arg(fp);
         }

--- a/src/ledcontrol.cpp
+++ b/src/ledcontrol.cpp
@@ -148,6 +148,8 @@ void LEDControl::setPath(QString fp)
         m_isValid = false;
     }
 
+    emit isValidPathChanged(m_isValid);
+
     // close the file
     file.close();
 


### PR DESCRIPTION
This two commits contain two changes which should improve the application by delivering better feedback to the user:
- The control file path for unknown devices is set to 'Unknown' making it more obvious that the device is not recognised
- Changes to LEDControl::m_isValid are now correctly emitted. This let the warning text 'Invalid control file path' on the settings page correctly disappear when a device is detected

(sorry for not submitting this earlier, but I was busy and wanted to test the changes properly)
